### PR TITLE
Add pages sasl user

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -55,3 +55,5 @@ variables:
     alternative_names: [ 10.244.8.64 ]
 - name: cloudgov_pw
   type: password
+- name: pages_pw
+  type: password

--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -28,3 +28,7 @@
 - type: replace
   path: /instance_groups/name=postfix/jobs/release=postfix/properties/postfix/sasl_users?/cloudgov
   value: ((cloudgov_pw))
+
+- type: replace
+  path: /instance_groups/name=postfix/jobs/release=postfix/properties/postfix/sasl_users?/pages
+  value: ((pages_pw))

--- a/bosh/secrets.example.yml
+++ b/bosh/secrets.example.yml
@@ -31,3 +31,5 @@ postfix_ssl:
 postfix_use_sasl: true
 # We use this password for the cloudgov sasl user.
 cloudgov_pw: XXX
+# We use this password for the pages sasl user.
+pages_pw: XXX

--- a/bosh/varsfiles/bosh-lite.yml
+++ b/bosh/varsfiles/bosh-lite.yml
@@ -7,6 +7,7 @@ postfix_dkim_maildomain: cloud.gov
 postfix_use_sasl: true
 postfix_sasl_users:
   cloudgov: testpw
+  pages: testpw
 # This key is just one I randomly generated.  It is not real.
 postfix_dkim_privatekey: |
   -----BEGIN RSA PRIVATE KEY-----

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -5,5 +5,6 @@ postfix_myhostname: smtp.fr.cloud.gov
 postfix_use_tls: true
 postfix_dkim_maildomain: cloud.gov
 postfix_use_sasl: true
-postfix_sasl_users: 
+postfix_sasl_users:
   cloudgov: ((cloudgov_pw))
+  pages: ((pages_pw))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -173,12 +173,18 @@ jobs:
       trigger: true
     - get: tests-timer
       trigger: true
-  - task: smoke-test-sasl
+  - task: smoke-test-cloudgov-sasl
     file: postfix-config/ci/verify-sasl.yml
     params:
       ENVIRONMENT: production
       USERNAME: cloudgov@fr.cloud.gov
       PASSWORD: ((cloudgov_pw))
+  - task: smoke-test-pages-sasl
+    file: postfix-config/ci/verify-sasl.yml
+    params:
+      ENVIRONMENT: production
+      USERNAME: pages@fr.cloud.gov
+      PASSWORD: ((pages_pw))
   on_success:
     put: slack
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Create a new SASL user for pages transactional email needs.
- Please provide feedback on feasibility and approach. This will support pages' transition and notification requirements.

## security considerations
- Creates a new user and credentials for use in cloud.gov pages