### PR TITLE
adding 5gb external presistent disk

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -22,6 +22,7 @@ instance_groups:
   vm_type: default
   instances: 1
   azs: [z1, z2]
+  persistent_disk_type: 5GB
   networks:
   - name: manual
     static_ips: [10.244.8.64]


### PR DESCRIPTION
## Changes proposed in this pull request:
- With the move to bionic, the default disk on a stemcell has less persistent storage and alerts on utilization so adding a separate 5 GB disk for storage

## security considerations
n/a
