### PR TITLE
update BOSH manifest and CI pipeline to use Jammy stemcells

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -13,7 +13,7 @@ update:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 instance_groups:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,10 +31,10 @@ resources:
     regexp: postfix-(.*).tgz
     region_name: ((aws-region))
 
-- name: stemcell-bionic
+- name: stemcell-jammy
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 
 - name: terraform-yaml
   type: s3-iam
@@ -74,7 +74,7 @@ jobs:
   serial_groups: [deploy]
   plan:
   - in_parallel:
-    - get: stemcell-bionic
+    - get: stemcell-jammy
       trigger: true
     - get: postfix-config
       trigger: true
@@ -88,7 +88,7 @@ jobs:
       manifest: postfix-config/bosh/manifest.yml
       dry_run: true
       stemcells:
-      - stemcell-bionic/*.tgz
+      - stemcell-jammy/*.tgz
       releases:
       - postfix-release/*.tgz
       ops_files:
@@ -124,7 +124,7 @@ jobs:
       passed: [plan-postfix-production]
     - get: postfix-release
       passed: [plan-postfix-production]
-    - get: stemcell-bionic
+    - get: stemcell-jammy
       passed: [plan-postfix-production]
     - get: terraform-yaml
       passed: [plan-postfix-production]
@@ -134,7 +134,7 @@ jobs:
     params:
       manifest: postfix-config/bosh/manifest.yml
       stemcells:
-      - stemcell-bionic/*.tgz
+      - stemcell-jammy/*.tgz
       releases:
       - postfix-release/*.tgz
       ops_files:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update BOSH manifest and CI pipeline to use Jammy stemcells

## security considerations

Bionic is EOL, so we need to update to Jammy so we can keep up to date on security patches
